### PR TITLE
Add ability to build specific branch/tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,15 @@ hello-world: ELF 32-bit LSB  executable, ARM, EABI5 version 1 (SYSV), statically
 
 ## Using the container's build command
 
-This container provides a special `build` command to build projects in git repositories.
+This container provides a special `build` command to build projects in Git repositories.
 
-The syntax is `build project-name` or `build url.git`, where `project-name` is the name of the DroboPorts project, and `url.git` is the URL of a git repository (e.g., https://github.com/droboports/busybox.git).
+The build command has two forms: `build PROJECT_NAME` and `build GIT_URL`.
 
-For DroboPorts projects, the name is the last component of the GitHub URL. For example, to build the project hosted by the repository https://github.com/droboports/busybox, use the name `busybox`.
+The `build PROJECT_NAME` form is a shortcut to build a project from the DroboPorts GitHub organization (https://github.com/droboports), with the `PROJECT_NAME` being the last component of the GitHub URL. For example, the `PROJECT_NAME` for the https://github.com/droboports/busybox project would be simply `busybox`.
+
+The `build GIT_URL` form allows any arbitrary Git repo to be built. For GitHub repos, `GIT_URL` would be the clone URL (e.g., https://github.com/droboports/busybox.git). The URL can optionally include a fragment ID to specify a branch or tag name. For example, to build the `v0.0.1` tag in your https://github.com/username/project.git repo, the `GIT_URL` would be `https://github.com/username/project.git#v0.0.1`. Without a branch or tag name specified, the [default Git branch](https://help.github.com/articles/setting-the-default-branch/) will be used.
+
+(Note that the building a specific branch or tag only works with the `build GIT_URL` form.)
 
 To use the build command, first create a folder to host the resulting packages:
 ```
@@ -80,7 +84,7 @@ chmod a+rw ~/dist
 
 Then start the container using the special `build` syntax:
 ```
-docker run --rm --volume ~/dist:/dist droboports/compiler build project-name
+docker run --rm --volume ~/dist:/dist droboports/compiler build PROJECT_NAME
 ```
 
-Once the build is done, `~/dist` will contain `project-name.tgz`.
+Once the build is done, `~/dist` will contain `PROJECT_NAME.tgz`.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,11 +17,36 @@ if [ "${1:-}" = "build" ]; then
   touch "/dist/.${_name}"
   rm -f "/dist/.${_name}"
   cd /home/drobo/build
+
+  # base assumptions: arg == URL, no branch/tag
+  _repo_url="${1}"
+  _branch_tag=""
+
+  # see if URL has a fragment ID ('#') indicating the branch/tag. ('0' means no)
+  _hash_idx=`expr index "${1}" '#'`
+  if [ "${_hash_idx}" != "0" ]; then
+    # NOTE: /bin/sh does not allow for advanced parameter expansions, hence the
+    # awk hoops we need to jump through to do simple substrings.
+    _repo_url=$(echo $1 | awk -v hashidx=$_hash_idx '{ s=substr($0, 0, hashidx); print s; }' )
+    _strlen=${#1}
+    _branch_tag=$(echo $1 | awk -v hashidx=$_hash_idx -v strlen=$_strlen '{ s=substr($0, hashidx + 1, strlen - 1); print s; }' )
+  fi
+
+  _name="$(basename "${_repo_url}" .git)"
+
   if [ "${_name}" = "${1}" ]; then
+    # arg is repo name, so assume it's a droboports repo
     git clone "https://github.com/droboports/${1}.git" "${_name}"
   else
-    git clone "${1}" "${_name}"
+    if [ "${_branch_tag}" = "" ]; then
+      # arg is repo URL without a branch/tag: https://github.com/user/repo.git
+      git clone "${1}" "${_name}"
+    else
+      # arg is repo URL with a branch/tag: https://github.com/user/repo.git#branch-or-tag-name
+      git clone -b "${_branch_tag}" --single-branch "${_repo_url}" "${_name}"
+    fi
   fi
+
   cd "${_name}"
   export GOPATH="/mnt/DroboFS/Shares/DroboApps/${_name}"
   shift

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,10 @@ if [ "${1:-}" = "build" ]; then
   _branch_tag=""
 
   # see if URL has a fragment ID ('#') indicating the branch/tag. ('0' means no)
-  _hash_idx=`expr index "${1}" '#'`
+  # NOTE: expr returns a non-zero exit status if it can't find the index, which
+  # stops the execution due to errexit. to work around this, we or the command
+  # with true to ensure the return value of the subshell is always true
+  _hash_idx=$(expr index "${1}" '#' || true)
   if [ "${_hash_idx}" != "0" ]; then
     # NOTE: /bin/sh does not allow for advanced parameter expansions, hence the
     # awk hoops we need to jump through to do simple substrings.


### PR DESCRIPTION
The `build` command now accepts a Git URL that optionally contains a fragment ID to specify the branch or tag name to build. This is a pretty common convention used in other Git-aware tools. See the README for more deets.

example using a branch:

```
docker run --rm --volume ~/dist:/dist droboports/compiler build https://github.com/blech75/htop.git#2.0.1-update
+ shift
+ basename https://github.com/blech75/htop.git#2.0.1-update .git
+ _name=htop.git#2.0.1-update
+ touch /dist/.htop.git#2.0.1-update
+ rm -f /dist/.htop.git#2.0.1-update
+ cd /home/drobo/build
+ _repo_url=https://github.com/blech75/htop.git#2.0.1-update
+ _branch_tag=
+ expr index https://github.com/blech75/htop.git#2.0.1-update #
+ _hash_idx=36
+ [ 36 != 0 ]
+ echo https://github.com/blech75/htop.git#2.0.1-update
+ awk -v hashidx=36 { s=substr($0, 0, hashidx); print s; }
+ _repo_url=https://github.com/blech75/htop.git
+ _strlen=48
+ echo https://github.com/blech75/htop.git#2.0.1-update
+ awk -v hashidx=36 -v strlen=48 { s=substr($0, hashidx + 1, strlen - 1); print s; }
+ _branch_tag=2.0.1-update
+ basename https://github.com/blech75/htop.git .git
+ _name=htop
+ [ htop = https://github.com/blech75/htop.git#2.0.1-update ]
+ [ 2.0.1-update =  ]
+ git clone -b 2.0.1-update --single-branch https://github.com/blech75/htop.git htop
Cloning into 'htop'...
+ cd htop
...
```

example using a tag:

```
docker run --rm --volume ~/dist:/dist droboports/compiler build https://github.com/blech75/htop.git#v2.0.1
+ shift
+ basename https://github.com/blech75/htop.git#v2.0.1 .git
+ _name=htop.git#v2.0.1
+ touch /dist/.htop.git#v2.0.1
+ rm -f /dist/.htop.git#v2.0.1
+ cd /home/drobo/build
+ _repo_url=https://github.com/blech75/htop.git#v2.0.1
+ _branch_tag=
+ expr index https://github.com/blech75/htop.git#v2.0.1 #
+ _hash_idx=36
+ [ 36 != 0 ]
+ echo https://github.com/blech75/htop.git#v2.0.1
+ awk -v hashidx=36 { s=substr($0, 0, hashidx); print s; }
+ _repo_url=https://github.com/blech75/htop.git
+ _strlen=42
+ echo https://github.com/blech75/htop.git#v2.0.1
+ awk -v hashidx=36 -v strlen=42 { s=substr($0, hashidx + 1, strlen - 1); print s; }
+ _branch_tag=v2.0.1
+ basename https://github.com/blech75/htop.git .git
+ _name=htop
+ [ htop = https://github.com/blech75/htop.git#v2.0.1 ]
+ [ v2.0.1 =  ]
+ git clone -b v2.0.1 --single-branch https://github.com/blech75/htop.git htop
Cloning into 'htop'...
Note: checking out 'aaf2f05f5eeda48c561dde3979252183af2fa2dd'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

+ cd htop
...
```
